### PR TITLE
Bump lib versions for Symfony 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 		"ext-pcntl": "*",
 		"predis/predis": "0.8.*",
 		"monolog/monolog": "1.7.*",
-		"symfony/console": "2.3.*",
-		"symfony/yaml": "2.3.*"
+		"symfony/console": "2.4.*",
+		"symfony/yaml": "2.4.*"
 	},
 	"suggest": {
 		"ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",
@@ -26,7 +26,7 @@
 	"require-dev": {
 		"sami/sami": "1.*",
 		"phpunit/phpunit": "3.7.*",
-		"symfony/process": "2.3.*"
+		"symfony/process": "2.4.*"
 	},
 	"bin": [
 		"bin/resque"


### PR DESCRIPTION
Attempting to install php-resque via composer in Symfony 2.4 projects fails due to unresolvable dependencies. Bump the requirements to enable installation. Tagged 1.1 for backwards compatibility.
