### PR TITLE
Fix autoloader file loading issue

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php 
+<?php
 /**
  * This file is part of the php-resque package.
  *
@@ -20,10 +20,23 @@ if (!ini_get('date.timezone') or !date_default_timezone_get()) {
 define('RESQUE_BIN_DIR', realpath(__DIR__));
 define('RESQUE_DIR', realpath(RESQUE_BIN_DIR.'/../'));
 
-if (file_exists($file = RESQUE_DIR.'/vendor/autoload.php')) {
-	require_once $file;
-	
-} else {
+$files = array(
+    RESQUE_DIR.'/vendor/autoload.php',
+    RESQUE_DIR.'/../../autoload.php'
+);
+
+$loaded = false;
+
+foreach ($files as $file)
+{
+    if (file_exists($file)) {
+        require_once $file;
+        $loaded = true;
+        break;
+    }
+}
+
+if (!$loaded) {
 	echo '<pre>You need to set up the project dependencies using the following commands:'.PHP_EOL.
 		"\t".'$ curl -s http://getcomposer.org/installer | php'.PHP_EOL.
 		"\t".'$ php composer.phar install</pre>'.PHP_EOL;


### PR DESCRIPTION
Fixes an issue where the autoload file would not be found by the script and report that the user needs to run `composer.phar install`. The script seems to be checking the wrong location for the file. Instead of using only one path, I made the script check both paths.
