### PR TITLE
fix broken linefeeds in CLI output

### DIFF
--- a/src/Resque/Logger/Handler/ConsoleHandler.php
+++ b/src/Resque/Logger/Handler/ConsoleHandler.php
@@ -123,7 +123,11 @@ class ConsoleHandler extends AbstractProcessingHandler {
 	 * {@inheritdoc}
 	 */
 	protected function getDefaultFormatter() {
-		return new Logger\Formatter\ConsoleFormatter;
+		$formatter = new Logger\Formatter\ConsoleFormatter;
+		if (method_exists($formatter, 'allowInlineLineBreaks')) {
+			$formatter->allowInlineLineBreaks(true);
+		}
+		return $formatter;
 	}
 
 	/**


### PR DESCRIPTION
Since monolog 1.8 newlines are stripped in LineFormatter by default ([1], linefeeds replaced by whitespace), however this breaks output of php-resque's CLI commands.

This patch checks for allowInlineLineBreaks method in monolog 1.8+ and allows linefeeds again.

[1] https://github.com/Seldaek/monolog/blob/master/CHANGELOG.mdown#180-2014-03-23