### PR TITLE
Redis AUTH password support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 [php-resque](https://github.com/mjphaynes/php-resque)
 ===========================================
 
-php-resque (pronounced like "rescue") is a Redis-backed library for creating 
+php-resque (pronounced like "rescue") is a Redis-backed library for creating
 background jobs, placing those jobs on multiple queues, and processing them later.
 
 [← Go back to main documentation](https://github.com/mjphaynes/php-resque)
@@ -56,6 +56,7 @@ There are some options that can be used for any command:
 * `port`      - The Redis port.
 * `scheme`    - The Redis scheme to use.
 * `namespace` - The Redis namespace to use. This is prefixed to all keys.
+* `password`  - The Redis AUTH password
 * `log`       - Specify the handler(s) to use for logging.
 * `events`    - Outputs all events to the console, for debugging.
 
@@ -83,18 +84,18 @@ And here are the command specific options:
 	* `args`           - The arguments to send with the job.
 	* `queue`          - The queue to add the job to.
 	* `delay`          - The amount of time or a unix time to delay execution of job till.
-* `clear`          
+* `clear`
 	* `force`          - Force without asking.
-* `socket:connect` 
+* `socket:connect`
 	* `connecthost`    - The host to connect to.
 	* `connectport`    - The port to connect to.
 	* `connecttimeout` - The connection timeout time (seconds).
-* `socket:receive` 
+* `socket:receive`
 	* `listenhost`     - The host to listen on.
 	* `listenport`     - The port to listen on.
 	* `listenretry`    - If can't bind address or port then retry every <timeout> seconds until it can.
 	* `listentimeout`  - The retry timeout time (seconds).
-* `socket:send`    
+* `socket:send`
 	* `cmd`            - The command to send to the receiver.
 	* `id`             - The id of the worker (optional; required for worker: commands).
 	* `connecthost`    - The host to send to.

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of the php-resque package.
  *
@@ -69,7 +69,7 @@ class Resque {
 
 		return call_user_func_array($callable, $parameters);
 	}
-	
+
 	/**
 	 * Reads and loads data from a config file
 	 *
@@ -83,7 +83,8 @@ class Resque {
 			'scheme'    => static::getConfig('redis.scheme', Redis::DEFAULT_SCHEME),
 			'host'      => static::getConfig('redis.host', Redis::DEFAULT_HOST),
 			'port'      => static::getConfig('redis.port', Redis::DEFAULT_PORT),
-			'namespace' => static::getConfig('redis.namespace', Redis::DEFAULT_NS)
+			'namespace' => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
+			'password'  => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD)
 		));
 
 		return true;
@@ -131,7 +132,7 @@ class Resque {
 
 		return static::$config = $yaml;
 	}
-	
+
 	/**
 	 * Gets Resque config variable
 	 *

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of the php-resque package.
  *
@@ -43,6 +43,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		'host'           => 'redis.host',
 		'port'           => 'redis.port',
 		'namespace'      => 'redis.namespace',
+		'password'       => 'redis.password',
 		'verbose'        => 'default.verbose',
 		'queue'          => 'default.jobs.queue',
 		'delay'          => 'default.jobs.delay',
@@ -78,6 +79,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 				new InputOption('port', 'p', InputOption::VALUE_OPTIONAL, 'The Redis port.', Resque\Redis::DEFAULT_PORT),
 				new InputOption('scheme', null, InputOption::VALUE_REQUIRED, 'The Redis scheme to use.', Resque\Redis::DEFAULT_SCHEME),
 				new InputOption('namespace', null, InputOption::VALUE_REQUIRED, 'The Redis namespace to use. This is prefixed to all keys.', Resque\Redis::DEFAULT_NS),
+				new InputOption('password', null, InputOption::VALUE_OPTIONAL, 'The Redis AUTH password.'),
 				new InputOption('log', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Specify the handler(s) to use for logging.'),
 				new InputOption('events', 'e', InputOption::VALUE_NONE, 'Outputs all events to the console, for debugging.'),
 			)
@@ -103,7 +105,8 @@ class Command extends \Symfony\Component\Console\Command\Command {
 			'scheme'    => $config['scheme'],
 			'host'      => $config['host'],
 			'port'      => $config['port'],
-			'namespace' => $config['namespace']
+			'namespace' => $config['namespace'],
+			'password'  => $config['password']
 		));
 
 		// Set the verbosity
@@ -127,14 +130,14 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		}
 
 		$this->logger = $logger = new Resque\Logger($handlers);
-		
+
 		// Unset some variables so as not to pass to include file
 		unset($logs, $handlerConnector, $handlers);
 
 		// Include file?
 		if (array_key_exists('include', $config) and strlen($include = $config['include'])) {
 			if (
-				!($includeFile = realpath(dirname($include).'/'.basename($include))) or 
+				!($includeFile = realpath(dirname($include).'/'.basename($include))) or
 				!is_readable($includeFile) or !is_file($includeFile) or
 				substr($includeFile, -4) !== '.php'
 			) {
@@ -143,13 +146,13 @@ class Command extends \Symfony\Component\Console\Command\Command {
 
 			try {
 				require_once $includeFile;
-				
+
 			} catch (\Exception $e) {
 				throw new \RuntimeException('The include file "'.$include.'" threw an exception: "'.$e->getMessage().'" on line '.$e->getLine());
 			}
 		}
-		
-		// This outputs all the events that are fired, useful for learning 
+
+		// This outputs all the events that are fired, useful for learning
 		// about when events are fired in the command flow
 		if (array_key_exists('events', $config) and $config['events'] === true) {
 			Resque\Event::listen('*', function($event) use ($output) {
@@ -186,7 +189,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	public function log() {
 		return call_user_func_array(array($this->logger, 'log'), func_get_args());
 	}
-	
+
 	/**
 	 * Parses the configuration file
 	 *
@@ -198,7 +201,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 
 			foreach ($config as $key => &$value) {
 				// If the config value is equal to the default value set in the command then
-				// have a look at the config file. This is so that the config options can be 
+				// have a look at the config file. This is so that the config options can be
 				// over-ridden in the command line.
 				if (
 					isset($this->configOptionMap[$key]) and
@@ -242,7 +245,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 
 		return false;
 	}
-	
+
 	/**
 	 * Returns all config items or a specific one
 	 *
@@ -253,7 +256,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 			if (!array_key_exists($key, $this->config)) {
 				throw new \InvalidArgumentException('Config key "'.$key.'" does not exist. Valid keys are: "'.implode(', ', array_keys($this->config)).'"');
 			}
-			
+
 			return $this->config[$key];
 		}
 

--- a/src/Resque/Logger/Handler/Connector/RedisConnector.php
+++ b/src/Resque/Logger/Handler/Connector/RedisConnector.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of the php-resque package.
  *
@@ -23,12 +23,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 class RedisConnector extends AbstractConnector {
 
 	public function resolve(Command $command, InputInterface $input, OutputInterface $output, array $args) {
-		$redis = new \Predis\Client(array(
+		$options = array(
 			'scheme' => 'tcp',
 			'host'   => $args['host'],
 			'port'   => $args['port']
-		));
-		
+		);
+
+		$password = Resque::getConfig('redis.password', Resque\Redis::DEFAULT_PASSWORD);
+		if ($password !== null && $password !== false && trim($password) !== '') {
+			$options['password'] = $password;
+		}
+
+		$redis = new \Predis\Client($options);
+
 		$namespace = Resque::getConfig('redis.namespace', Resque\Redis::DEFAULT_NS);
 		if (substr($namespace, -1) !== ':') {
 			$namespace .= ':';

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of the php-resque package.
  *
@@ -18,7 +18,7 @@ use Resque\Helpers\Stats;
  * @author Michael Haynes <mike@mjphaynes.com>
  */
 class Redis {
-	
+
 	/**
 	 * Default Redis connection scheme
 	 */
@@ -40,13 +40,19 @@ class Redis {
 	const DEFAULT_NS = 'resque';
 
 	/**
+	* Default Redis AUTH password
+	*/
+	const DEFAULT_PASSWORD = null;
+
+	/**
 	 * @var array Default configuration
 	 */
 	protected static $config = array(
 		'scheme'    => self::DEFAULT_SCHEME,
 		'host'      => self::DEFAULT_HOST,
 		'port'      => self::DEFAULT_PORT,
-		'namespace' => self::DEFAULT_NS
+		'namespace' => self::DEFAULT_NS,
+		'password'  => self::DEFAULT_PASSWORD
 	);
 
 	/**
@@ -63,7 +69,7 @@ class Redis {
 		if (!static::$instance) {
 			static::$instance = new static(static::$config);
 		}
-		
+
 		return static::$instance;
 	}
 
@@ -162,7 +168,7 @@ class Redis {
 		// mset
 		// renamenx
 	);
-	
+
 	/**
 	 * Establish a Redis connection.
 	 *
@@ -170,12 +176,22 @@ class Redis {
 	 * @return Redis
 	 */
 	public function __construct(array $config = array()) {
-		$this->redis = new Predis\Client(array(
+		// configuration options array
+		$options = array(
 			'scheme' => $config['scheme'],
 			'host'   => $config['host'],
 			'port'   => $config['port']
-		));
-		
+		);
+
+		// setup password
+		if (!empty($config['password'])) {
+			$options['password'] = $config['password'];
+		}
+
+		// create Predis client
+		$this->redis = new Predis\Client($options);
+
+		// setup namespace
 		if (!empty($config['namespace'])) {
 			$this->setNamespace($config['namespace']);
 		} else {
@@ -219,10 +235,10 @@ class Redis {
 			foreach ($string as &$str) {
  				$str = $this->addNamespace($str);
 			}
-			
+
 			return $string;
 		}
-		
+
 		if (strpos($string, $this->namespace) !== 0) {
 			$string = $this->namespace.$string;
 		}
@@ -260,7 +276,7 @@ class Redis {
 
 		// try {
 			return call_user_func_array(array($this->redis, $method), $parameters);
-			
+
 		// } catch (\Exception $e) {
 		// 	return false;
 		// }


### PR DESCRIPTION
A Redis server can be configured to require password authentication[1]. 

This patch adds a password parameter (config files and command line) to pass AUTH credentials to the predis middleware.

[1] http://redis.io/commands/auth
