### PR TITLE
Remove optional proctitle extension dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"symfony/process": "~2.3"
 	},
 	"suggest": {
+		"ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker in PHP versions < 5.5.0.",
 		"ext-redis": "Native PHP extension for Redis connectivity. Predis will automatically utilize when available."
 	},
 	"require-dev": {

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -1154,14 +1154,33 @@ class Worker {
 	}
 
 	/**
-	 * On supported systems (with the PECL proctitle module installed), update
-	 * the name of the currently running process to indicate the current state
-	 * of a worker.
-	 *
+	 * On supported systems, update the name of the currently running process
+	 * to indicate the current state of a worker.
+	 * 
+	 * supported systems are
+	 * - PHP Version < 5.5.0 with the PECL proctitle module installed
+	 * - PHP Version >= 5.5.0 using built in method
+	 * 
 	 * @param string $status The updated process title.
 	 */
 	protected function updateProcLine($status) {
-		cli_set_process_title(sprintf('resque-%s: %s', \Resque::VERSION, $status));
+		$status = $this->getProcessTitle($status);
+		if (function_exists('cli_set_process_title')) {
+			cli_set_process_title($status);
+			return;
+		}
+		
+		if (function_exists('setproctitle')) {
+			setproctitle($status);
+		}
+		return;
+	}
+	
+	/**
+	 * Creates process title string from current version and status of worker
+	 */
+	protected function getProcessTitle($status) {
+		return sprintf('resque-%s: %s', \Resque::VERSION, $status);
 	}
 
 	/**

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -1173,7 +1173,6 @@ class Worker {
 		if (function_exists('setproctitle')) {
 			setproctitle($status);
 		}
-		return;
 	}
 	
 	/**


### PR DESCRIPTION
The proctitle extension is outdated and has several issues
* extension causes segfaults on PHP >= 5.5
* see issue tracker https://github.com/MagicalTux/proctitle/issues
* there is built in method for setting process title

This PR replaces the usage of proctitle