### PR TITLE
Feature/support read write timeout setting

### DIFF
--- a/src/Resque.php
+++ b/src/Resque.php
@@ -84,7 +84,8 @@ class Resque {
 			'host'      => static::getConfig('redis.host', Redis::DEFAULT_HOST),
 			'port'      => static::getConfig('redis.port', Redis::DEFAULT_PORT),
 			'namespace' => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
-			'password'  => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD)
+			'password'  => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
+			'read_write_timeout'  => static::getConfig('redis.read_write_timeout', Redis::DEFAULT_RW_TIMEOUT),
 		));
 
 		return true;

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -85,7 +85,7 @@ class Resque {
 			'port'      => static::getConfig('redis.port', Redis::DEFAULT_PORT),
 			'namespace' => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
 			'password'  => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
-			'read_write_timeout'  => static::getConfig('redis.read_write_timeout', Redis::DEFAULT_RW_TIMEOUT),
+			'rw_timeout' => static::getConfig('redis.rw_timeout', Redis::DEFAULT_RW_TIMEOUT),
 		));
 
 		return true;

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -180,7 +180,8 @@ class Redis {
 		$options = array(
 			'scheme' => $config['scheme'],
 			'host'   => $config['host'],
-			'port'   => $config['port']
+			'port'   => $config['port'],
+			'read_write_timeout' => isset($config['read_write_timeout']) ? $config['read_write_timeout'] : 240,
 		);
 
 		// setup password

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -58,7 +58,7 @@ class Redis {
 		'port'      => self::DEFAULT_PORT,
 		'namespace' => self::DEFAULT_NS,
 		'password'  => self::DEFAULT_PASSWORD,
-		'read_write_timeout' => self::DEFAULT_RW_TIMEOUT,
+		'rw_timeout' => self::DEFAULT_RW_TIMEOUT,
 	);
 
 	/**
@@ -187,7 +187,7 @@ class Redis {
 			'scheme' => $config['scheme'],
 			'host'   => $config['host'],
 			'port'   => $config['port'],
-			'read_write_timeout' => $config['read_write_timeout'],
+			'rw_timeout' => $config['rw_timeout'],
 		);
 
 		// setup password

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -47,7 +47,7 @@ class Redis {
 	/**
 	 * Default Redis Read Write Timeout
 	 */
-	const DEFAULT_RW_TIMEOUT = 300;
+	const DEFAULT_RW_TIMEOUT = 60;
 
 	/**
 	 * @var array Default configuration

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -45,6 +45,11 @@ class Redis {
 	const DEFAULT_PASSWORD = null;
 
 	/**
+	 * Default Redis Read Write Timeout
+	 */
+	const DEFAULT_RW_TIMEOUT = 300;
+
+	/**
 	 * @var array Default configuration
 	 */
 	protected static $config = array(
@@ -52,7 +57,8 @@ class Redis {
 		'host'      => self::DEFAULT_HOST,
 		'port'      => self::DEFAULT_PORT,
 		'namespace' => self::DEFAULT_NS,
-		'password'  => self::DEFAULT_PASSWORD
+		'password'  => self::DEFAULT_PASSWORD,
+		'read_write_timeout' => self::DEFAULT_RW_TIMEOUT,
 	);
 
 	/**
@@ -181,7 +187,7 @@ class Redis {
 			'scheme' => $config['scheme'],
 			'host'   => $config['host'],
 			'port'   => $config['port'],
-			'read_write_timeout' => isset($config['read_write_timeout']) ? $config['read_write_timeout'] : 240,
+			'read_write_timeout' => $config['read_write_timeout'],
 		);
 
 		// setup password


### PR DESCRIPTION
The default timeout is 60s.
This causes failures on longer running task where the redis connection gets lost.

This PR enables configuration over the yaml config file.

For issue description see SO Discussion at http://stackoverflow.com/questions/11776029/predis-is-giving-error-while-reading-line-from-server
