### PR TITLE
Fixes #30

### DIFF
--- a/src/Resque/Helpers/SerializableClosure.php
+++ b/src/Resque/Helpers/SerializableClosure.php
@@ -81,7 +81,8 @@ class SerializableClosure implements Serializable {
 			$code .= $file->current(); $file->next();
 		}
 
-		$begin = strpos($code, 'function(');
+		preg_match('/function\s*\(/', $code, $matches, PREG_OFFSET_CAPTURE);
+		$begin = isset($matches[0][1]) ? $matches[0][1] : 0;
 
 		return substr($code, $begin, strrpos($code, '}') - $begin + 1);
 	}


### PR DESCRIPTION
Uses a regex with 0 or more whitespaces matched between `function` and `(` to ensure that all code styles are captured when serializing the closure source code.

Fixed issue #30