### PR TITLE
add documentation (#15) for custom config when adding jobs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,21 @@ You can set the configuration file path when running any command:
 $ bin/resque [command] -c /path/to/config.yml
 ```
 
+When adding jobs to the queue, you just can add the config file location as parameter:
 
+```php
+\Resque::loadConfig('my-custom-config.yml');
+
+$payload = [
+    'some' => 'data',
+];
+
+$job = \Resque::push(
+    '\MyApplication\Jobs\TestJob', // your custom job class 
+    $payload,                      // data available in job
+    'default'                      // queue name
+);
+```
 
 ---
 


### PR DESCRIPTION
added doc block for usage example of custom config file when creating jobs/working with Rescue

closes #15 