### PR TITLE
add job done event

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -46,6 +46,9 @@ Resque\Event::listen(Resque\Event::JOB_COMPLETE, function($event, $job) {
 });
 ```
 
+The `Resque\Event::JOB_DONE` is triggered as last action in the job processing. While `Resque\Event::JOB_COMPLETE` is triggered after the jobs `perform()` method is finished, the `Resque\Event::JOB_DONE` Event is triggered after job output is stored in redis backend.
+In short: `Resque\Event::JOB_COMPLETE` is fired, when the jobs perform method work is done, while `Resque\Event::JOB_DONE` is fired, when the whole job processing is coming to an end.
+
 ### Worker events ###
 
 * `Resque\Event::WORKER_INSTANCE`       - New worker is created
@@ -83,6 +86,7 @@ Resque\Event::listen(Resque\Event::JOB_COMPLETE, function($event, $job) {
 * `Resque\Event::JOB_COMPLETE`       - Job has completed
 * `Resque\Event::JOB_CANCELLED`      - Job has been cancelled
 * `Resque\Event::JOB_FAILURE`        - Job has failed
+* `Resque\Event::JOB_DONE`           - Job is done
 
 
 ---

--- a/src/Resque/Event.php
+++ b/src/Resque/Event.php
@@ -54,6 +54,7 @@ class Event
     const JOB_COMPLETE       = 209;
     const JOB_CANCELLED      = 210;
     const JOB_FAILURE        = 211;
+    const JOB_DONE           = 212;
 
     /**
      * @var array containing all registered callbacks, indexed by event name

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -347,6 +347,8 @@ class Job
 
         $this->redis->hset(self::redisKey($this), 'output', $output);
 
+        Event::fire(Event::JOB_DONE, $this);
+
         return $retval;
     }
 


### PR DESCRIPTION
Add JOB_DONE Event to be triggered as last action in the perform method. This allows Event Listeners for Jobs in the short circuit processes to access job output and other packet data.

closes #53 