### PR TITLE
Fix #57: Use pcntl_async_signals if available (PHP 7.1)

### DIFF
--- a/src/Resque/Socket/Server.php
+++ b/src/Resque/Socket/Server.php
@@ -187,7 +187,12 @@ class Server
         }
 
         if (function_exists('pcntl_signal')) {
-            declare (ticks = 1);
+            // PHP 7.1 allows async signals
+            if (function_exists('pcntl_async_signals')) {
+                pcntl_async_signals(true);
+            } else {
+                declare(ticks = 1);
+            }
             pcntl_signal(SIGTERM, array($this, 'shutdown'));
             pcntl_signal(SIGINT, array($this, 'shutdown'));
             pcntl_signal(SIGQUIT, array($this, 'shutdown'));

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -505,7 +505,12 @@ class Worker
         if (function_exists('pcntl_signal')) {
             $this->log('Registering sig handlers for worker '.$this, Logger::DEBUG);
 
-            declare (ticks = 1);
+            // PHP 7.1 allows async signals
+            if (function_exists('pcntl_async_signals')) {
+                pcntl_async_signals(true);
+            } else {
+                declare(ticks = 1);
+            }
             pcntl_signal(SIGTERM, array($this, 'sigForceShutdown'));
             pcntl_signal(SIGINT, array($this, 'sigForceShutdown'));
             pcntl_signal(SIGQUIT, array($this, 'sigShutdown'));


### PR DESCRIPTION
See the comments in https://github.com/mjphaynes/php-resque/issues/57

Currently UNTESTED. @xelan if you get a chance to test it real quick, that'd be cool, since you're on 7.1 as you said in another thread.

I don't expect this to break anything though, this is a pretty standard "only use if it's available" check, so it shouldn't break old versions at all. Plus, like I referenced in the other issue, some other libs implemented it exactly the same way, so I don't see why it would be a problem.