### PR TITLE
[WIP] borrow TLS support from predis/predis

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,6 +57,8 @@ There are some options that can be used for any command:
 * `scheme`    - The Redis scheme to use.
 * `namespace` - The Redis namespace to use. This is prefixed to all keys.
 * `password`  - The Redis AUTH password
+* `ssl-cafile`  - The Redis SSL cafile path.
+* `ssl-verify_peer`  - The Redis SSL verify_peer.
 * `log`       - Specify the handler(s) to use for logging.
 * `events`    - Outputs all events to the console, for debugging.
 

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -89,8 +89,8 @@ class Resque
             'port'       => static::getConfig('redis.port', Redis::DEFAULT_PORT),
             'namespace'  => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
             'password'   => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
-            'ssl-cafile' => static::getConfig('redis.ssl', Redis::DEFAULT_SSL_CAFILE),
-            'ssl-verify_peer' => static::getConfig('redis.ssl', Redis::DEFAULT_SSL_VERIFY_PEER),
+            'ssl-cafile' => static::getConfig('redis.ssl-cafile', Redis::DEFAULT_SSL_CAFILE),
+            'ssl-verify_peer' => static::getConfig('redis.ssl-verify_peer', Redis::DEFAULT_SSL_VERIFY_PEER),
             'rw_timeout' => static::getConfig('redis.rw_timeout', Redis::DEFAULT_RW_TIMEOUT),
             'phpiredis'  => static::getConfig('redis.phpiredis', Redis::DEFAULT_PHPIREDIS)
         ));

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -89,6 +89,7 @@ class Resque
             'port'       => static::getConfig('redis.port', Redis::DEFAULT_PORT),
             'namespace'  => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
             'password'   => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
+            'ssl'        => static::getConfig('redis.ssl', Redis::DEFAULT_SSL),
             'rw_timeout' => static::getConfig('redis.rw_timeout', Redis::DEFAULT_RW_TIMEOUT),
             'phpiredis'  => static::getConfig('redis.phpiredis', Redis::DEFAULT_PHPIREDIS)
         ));

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -89,7 +89,8 @@ class Resque
             'port'       => static::getConfig('redis.port', Redis::DEFAULT_PORT),
             'namespace'  => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
             'password'   => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
-            'ssl'        => static::getConfig('redis.ssl', Redis::DEFAULT_SSL),
+            'ssl-cafile' => static::getConfig('redis.ssl', Redis::DEFAULT_SSL_CAFILE),
+            'ssl-verify_peer' => static::getConfig('redis.ssl', Redis::DEFAULT_SSL_VERIFY_PEER),
             'rw_timeout' => static::getConfig('redis.rw_timeout', Redis::DEFAULT_RW_TIMEOUT),
             'phpiredis'  => static::getConfig('redis.phpiredis', Redis::DEFAULT_PHPIREDIS)
         ));

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -45,6 +45,8 @@ class Command extends \Symfony\Component\Console\Command\Command
         'port'           => 'redis.port',
         'namespace'      => 'redis.namespace',
         'password'       => 'redis.password',
+        'ssl-cafile'     => 'redis.ssl.cafile',
+        'ssl-verify_peer'=> 'redis.ssl.verify_peer',
         'verbose'        => 'default.verbose',
         'queue'          => 'default.jobs.queue',
         'delay'          => 'default.jobs.delay',
@@ -81,7 +83,9 @@ class Command extends \Symfony\Component\Console\Command\Command
                 new InputOption('port', 'p', InputOption::VALUE_OPTIONAL, 'The Redis port.', Resque\Redis::DEFAULT_PORT),
                 new InputOption('scheme', null, InputOption::VALUE_REQUIRED, 'The Redis scheme to use.', Resque\Redis::DEFAULT_SCHEME),
                 new InputOption('namespace', null, InputOption::VALUE_REQUIRED, 'The Redis namespace to use. This is prefixed to all keys.', Resque\Redis::DEFAULT_NS),
-                new InputOption('password', null, InputOption::VALUE_OPTIONAL, 'The Redis AUTH password.'),
+                new InputOption('password', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS cafile path.'),
+                new InputOption('ssl-cafile', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS verify_peer.'),
+                new InputOption('ssl-verify_peer', null, InputOption::VALUE_OPTIONAL, 'The Redis AUTH password.'),
                 new InputOption('log', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Specify the handler(s) to use for logging.'),
                 new InputOption('events', 'e', InputOption::VALUE_NONE, 'Outputs all events to the console, for debugging.'),
             )
@@ -109,7 +113,8 @@ class Command extends \Symfony\Component\Console\Command\Command
             'host'      => $config['host'],
             'port'      => $config['port'],
             'namespace' => $config['namespace'],
-            'password'  => $config['password']
+            'password'  => $config['password'],
+            'ssl'  => $config['ssl']
         ));
 
         // Set the verbosity

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -83,9 +83,9 @@ class Command extends \Symfony\Component\Console\Command\Command
                 new InputOption('port', 'p', InputOption::VALUE_OPTIONAL, 'The Redis port.', Resque\Redis::DEFAULT_PORT),
                 new InputOption('scheme', null, InputOption::VALUE_REQUIRED, 'The Redis scheme to use.', Resque\Redis::DEFAULT_SCHEME),
                 new InputOption('namespace', null, InputOption::VALUE_REQUIRED, 'The Redis namespace to use. This is prefixed to all keys.', Resque\Redis::DEFAULT_NS),
-                new InputOption('password', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS cafile path.'),
-                new InputOption('ssl-cafile', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS verify_peer.'),
-                new InputOption('ssl-verify_peer', null, InputOption::VALUE_OPTIONAL, 'The Redis AUTH password.'),
+                new InputOption('password', null, InputOption::VALUE_OPTIONAL, 'The Redis AUTH password.'),
+                new InputOption('ssl-cafile', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS cafile path.', Resque\Redis::DEFAULT_SSL_CAFILE),
+                new InputOption('ssl-verify_peer', null, InputOption::VALUE_OPTIONAL, 'The Redis TLS verify_peer.', Resque\Redis::DEFAULT_SSL_VERIFY_PEER),
                 new InputOption('log', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Specify the handler(s) to use for logging.'),
                 new InputOption('events', 'e', InputOption::VALUE_NONE, 'Outputs all events to the console, for debugging.'),
             )

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -115,7 +115,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             'namespace' => $config['namespace'],
             'password'  => $config['password'],
             'ssl-cafile'=> $config['ssl-cafile'], 
-            'verify_peer'=>$config['ssl-verify_peer']
+            'ssl-verify_peer'=>$config['ssl-verify_peer']
         ));
 
         // Set the verbosity

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -45,8 +45,8 @@ class Command extends \Symfony\Component\Console\Command\Command
         'port'           => 'redis.port',
         'namespace'      => 'redis.namespace',
         'password'       => 'redis.password',
-        'ssl-cafile'     => 'redis.ssl.cafile',
-        'ssl-verify_peer'=> 'redis.ssl.verify_peer',
+        'ssl-cafile'     => 'redis.ssl-cafile',
+        'ssl-verify_peer'=> 'redis.ssl-verify_peer',
         'verbose'        => 'default.verbose',
         'queue'          => 'default.jobs.queue',
         'delay'          => 'default.jobs.delay',
@@ -114,7 +114,8 @@ class Command extends \Symfony\Component\Console\Command\Command
             'port'      => $config['port'],
             'namespace' => $config['namespace'],
             'password'  => $config['password'],
-            'ssl'       => array('catfile'=>$config['ssl-cafile'], 'verify_peer'=>$config['ssl-verify_peer'])
+            'ssl-cafile'=> $config['ssl-cafile'], 
+            'verify_peer'=>$config['ssl-verify_peer']
         ));
 
         // Set the verbosity

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -114,7 +114,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             'port'      => $config['port'],
             'namespace' => $config['namespace'],
             'password'  => $config['password'],
-            'ssl'  => $config['ssl']
+            'ssl'       => array('catfile'=>$config['ssl-cafile'], 'verify_peer'=>$config['ssl-verify_peer'])
         ));
 
         // Set the verbosity

--- a/src/Resque/Logger/Handler/Connector/RedisConnector.php
+++ b/src/Resque/Logger/Handler/Connector/RedisConnector.php
@@ -36,6 +36,12 @@ class RedisConnector extends AbstractConnector
             $options['password'] = $password;
         }
 
+        $ssl = Resque::getConfig('redis.ssl', Resque\Redis::DEFAULT_SSL);
+        if ($ssl !== null && $ssl !== false && is_array($ssl)) {
+            $options['ssl'] = $ssl;
+        }
+
+
         $redis = new \Predis\Client($options);
 
         $namespace = Resque::getConfig('redis.namespace', Resque\Redis::DEFAULT_NS);

--- a/src/Resque/Logger/Handler/Connector/RedisConnector.php
+++ b/src/Resque/Logger/Handler/Connector/RedisConnector.php
@@ -36,9 +36,9 @@ class RedisConnector extends AbstractConnector
             $options['password'] = $password;
         }
 
-        $ssl = Resque::getConfig('redis.ssl', Resque\Redis::DEFAULT_SSL);
-        if ($ssl !== null && $ssl !== false && is_array($ssl)) {
-            $options['ssl'] = $ssl;
+        $sslCafile = Resque::getConfig('redis.ssl-cafile', Resque\Redis::DEFAULT_SSL_CAFILE);
+        if ($sslCafile !== null && $sslCafile !== false && is_array($sslCafile)) {
+            $options['ssl'] = array('cafile'=>$sslCafile, 'verify_peer'=>Resque::getConfig('redis.ssl-verify_peer', Resque\Redis::DEFAULT_SSL_VERIFY_PEER));
         }
 
 

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -71,7 +71,7 @@ class Redis
         'namespace'  => self::DEFAULT_NS,
         'password'   => self::DEFAULT_PASSWORD,
         'ssl-cafile' => self::DEFAULT_SSL_CAFILE,
-        'ssl-verify_peeor'=> self::DEFAULT_SSL_VERIFY_PEER,
+        'ssl-verify_peer'=> self::DEFAULT_SSL_VERIFY_PEER,
         'rw_timeout' => self::DEFAULT_RW_TIMEOUT,
         'phpiredis'  => self::DEFAULT_PHPIREDIS
     );

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -48,7 +48,8 @@ class Redis
     /**
     * Default Redis SSL options
     */
-    const DEFAULT_SSL = array();
+    const DEFAULT_SSL_CAFILE = null;
+    const DEFAULT_SSL_VERIFY_PEER = false;
 
     /**
      * Default Redis Read Write Timeout
@@ -69,7 +70,8 @@ class Redis
         'port'       => self::DEFAULT_PORT,
         'namespace'  => self::DEFAULT_NS,
         'password'   => self::DEFAULT_PASSWORD,
-        'ssl'        => self::DEFAULT_SSL,
+        'ssl-cafile' => self::DEFAULT_SSL_CAFILE,
+        'ssl-verify_peeor'=> self::DEFAULT_SSL_VERIFY_PEER,
         'rw_timeout' => self::DEFAULT_RW_TIMEOUT,
         'phpiredis'  => self::DEFAULT_PHPIREDIS
     );
@@ -211,8 +213,11 @@ class Redis
         }
 
         // setup ssl
-        if (!empty($config['ssl'])) {
-            $params['ssl'] = $config['ssl'];
+        if (!empty($config['ssl-cafile'])) {
+            $params['ssl'] = array(
+            	'cafile'=>$config['ssl-cafile'],
+            	'verify_peer'=>$config['ssl-verify_peer']
+            );	
         }
 
 

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -46,6 +46,11 @@ class Redis
     const DEFAULT_PASSWORD = null;
 
     /**
+    * Default Redis SSL options
+    */
+    const DEFAULT_SSL = array();
+
+    /**
      * Default Redis Read Write Timeout
      */
     const DEFAULT_RW_TIMEOUT = 60;
@@ -64,6 +69,7 @@ class Redis
         'port'       => self::DEFAULT_PORT,
         'namespace'  => self::DEFAULT_NS,
         'password'   => self::DEFAULT_PASSWORD,
+        'ssl'        => self::DEFAULT_SSL,
         'rw_timeout' => self::DEFAULT_RW_TIMEOUT,
         'phpiredis'  => self::DEFAULT_PHPIREDIS
     );
@@ -203,6 +209,12 @@ class Redis
         if (!empty($config['password'])) {
             $params['password'] = $config['password'];
         }
+
+        // setup ssl
+        if (!empty($config['ssl'])) {
+            $params['ssl'] = $config['ssl'];
+        }
+
 
         // setup read/write timeout
         if (!empty($config['rw_timeout'])) {


### PR DESCRIPTION
"ssl-cafile", "ssl-verify_peer" options are added.
Those keys are then turned into [cafile=>"absolute path to ca file", ssl-verify_peer => boolean] and applied to redis client. 

tested with predis. 
not tested with php-redis( I have no knoledge of this one...so.).
Wish we had a way to pass an instanciated redis client to Resque somehow.