### PR TITLE
added psr containers to php-resque to be injected into the user land jobs, thus allowing config options to be set without altering php-resque.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "monolog/monolog": "~1.7",
         "symfony/console": "~2.7|~3.0",
         "symfony/yaml": "~2.7|~3.0",
-        "symfony/process": "~2.7|~3.0"
+        "symfony/process": "~2.7|~3.0",
+        "psr/container": "*@stable"
     },
     "suggest": {
         "ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker in PHP versions < 5.5.0.",

--- a/examples/bootstrap/tiny_bootstrap.php
+++ b/examples/bootstrap/tiny_bootstrap.php
@@ -9,7 +9,10 @@ use Pimple\Container;
 
 $container = new Container();
 
-require __DIR__ . '/config/resque.conf.php';
+# some configurations
+$container['some_config_option'] = function($container) {
+  return 42;
+};
 
 $worker = new \Resque\Worker('some_queue', true);
 $worker->setPidFile('/tmp/some_queue_worker.pid');
@@ -17,7 +20,7 @@ $worker->setInterval(2);
 $worker->setTimeout(60);
 $worker->setMemoryLimit(128);
 $worker->setLogger();
-$worker->setContainer($container);
+$worker->setContainer($container); # will be available in the user land jobs
 
 if ('dev' == APPLICATION_ENV) {
     $logger = new \Resque\Logger([new \Monolog\Handler\StreamHandler('php://stdout', \Monolog\Logger::DEBUG)]);

--- a/examples/bootstrap/tiny_bootstrap.php
+++ b/examples/bootstrap/tiny_bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+define('APPLICATION_ENV', (getenv('APPLICATION_ENV') ?: 'dev'));
+const APPLICATION_ROOT = __DIR__;
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Pimple\Container;
+
+$container = new Container();
+
+require __DIR__ . '/config/resque.conf.php';
+
+$worker = new \Resque\Worker('some_queue', true);
+$worker->setPidFile('/tmp/some_queue_worker.pid');
+$worker->setInterval(2);
+$worker->setTimeout(60);
+$worker->setMemoryLimit(128);
+$worker->setLogger();
+$worker->setContainer($container);
+
+if ('dev' == APPLICATION_ENV) {
+    $logger = new \Resque\Logger([new \Monolog\Handler\StreamHandler('php://stdout', \Monolog\Logger::DEBUG)]);
+    $worker->setLogger($logger);
+}
+
+$worker->work();

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -11,6 +11,7 @@ namespace Resque;
 
 use Closure;
 use Resque\Helpers\Stats;
+use Psr\Container\ContainerInterface;
 
 /**
  * Resque job class
@@ -77,6 +78,11 @@ class Job
      * @var object Instance of the class performing work for this job
      */
     protected $instance;
+
+    /**
+     * @var ContainerInterface local container
+     */
+    protected $container = null;
 
     /**
      * @var array of statuses that are considered final/complete
@@ -315,6 +321,10 @@ class Job
 
         try {
             $instance = $this->getInstance();
+
+            if (!is_null($this->container) && method_exists($instance, 'setContainer')) {
+              $instance->setContainer($this->container);
+            }
 
             ob_start();
 
@@ -733,6 +743,24 @@ class Job
     public function setWorker(Worker $worker)
     {
         $this->worker = $worker;
+    }
+
+    /**
+     * Retrieve local container
+     *
+     * @return ContainerInterface
+     */
+    public function getContainer() {
+        return $this->container;
+    }
+
+    /**
+     * Set local container
+     *
+     * @param ContainerInterface the container to be injected into user land jobs
+     */
+    public function setContainer(ContainerInterface $container) {
+        $this->container = $container;
     }
 
     /**

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -913,6 +913,10 @@ class Worker
         return $workers;
     }
 
+    /****
+     * start SETTER / GETTER section
+     ****/
+
     /**
      * Get the worker id.
      *
@@ -1076,21 +1080,6 @@ class Worker
     }
 
     /**
-     * Helper function that passes through to logger instance
-     *
-     * @see    Logger::log For more documentation
-     * @return mixed
-     */
-    public function log()
-    {
-        if ($this->logger !== null) {
-            return call_user_func_array(array($this->logger, 'log'), func_get_args());
-        }
-
-        return false;
-    }
-
-    /**
      * Get the queue blocking.
      *
      * @return bool
@@ -1186,6 +1175,25 @@ class Worker
 
         $this->memoryLimit = $memoryLimit;
     }
+
+    /****
+     * end SETTER / GETTER section
+     ****/
+
+     /**
+      * Helper function that passes through to logger instance
+      *
+      * @see    Logger::log For more documentation
+      * @return mixed
+      */
+     public function log()
+     {
+         if ($this->logger !== null) {
+             return call_user_func_array(array($this->logger, 'log'), func_get_args());
+         }
+
+         return false;
+     }
 
     /**
      * Return array representation of this job

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -10,6 +10,7 @@
 namespace Resque;
 
 use Resque\Helpers\Stats;
+use Psr\Container\ContainerInterface;
 
 /**
  * Resque worker class
@@ -132,6 +133,11 @@ class Worker
      * @var Logger logger instance
      */
     protected $logger = null;
+
+    /**
+     * @var ContainerInterface local container class
+     */
+    protected $container = null;
 
     /**
      * Get the Redis key
@@ -358,6 +364,10 @@ class Worker
         // up the console
         set_time_limit($this->timeout);
         ini_set('display_errors', 0);
+
+        if (!is_null($this->container)) {
+          $job->setContainer($this->container);
+        }
 
         $job->perform();
 
@@ -1174,6 +1184,24 @@ class Worker
         }
 
         $this->memoryLimit = $memoryLimit;
+    }
+
+    /**
+     * Retrieve the local container
+     *
+     * @return ContainerInterface the local container
+     **/
+     public function getContainer() {
+        return $this->container;
+     }
+
+    /**
+     * Add a container
+     *
+     * @param ContainerInterface the container to be injected into the user land job
+     */
+    public function setContainer(ContainerInterface $container) {
+        $this->container = $container;
     }
 
     /****


### PR DESCRIPTION
practical side-effect (and why i am doing this):
user land jobs become testable without their dependencies (as in service classes, command line tools, stuff that only works on different hardware, than the current testing setup)