### PR TITLE
provide predis native configuration option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+[*.{js,json,rb,erb,scss,css}]
+indent_size = 2
+
+[*.{php,twig,yml}]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+
+# do not deploy docker testing stuff
+/docker export-ignore
+docker-compose.yml export-ignore
+
+# do not deploy git stuff
+.gitattributes
+.gitignore
+.git
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,3 @@ docker-compose.yml export-ignore
 .gitattributes
 .gitignore
 .git
-

--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@
 
 include: examples/autoload.php  # A file to include on each command
 
-
+# # The legacy way, which only supports a subset of Redis options
 # redis:
 #     scheme: tcp         # The connection scheme
 #     host: 127.0.0.1     # The hostname to connect to
@@ -20,6 +20,20 @@ include: examples/autoload.php  # A file to include on each command
 #     rw_timeout: 60      # Redis read/write timeout
 #     phpiredis: false    # Should use phpiredis php extension (must be installed)
 
+# # the predis native way (sentinel example)
+# # "config" is the first parameter to Predis\Client
+# # "options" is the second parameter to Predis\Client
+# predis:
+#   config:
+#     - "tcp://10.0.0.1:12345"
+#     - "tcp://10.0.0.2:12345"
+#     - "tcp://10.0.0.3:12345"
+#   options:
+#     service: "some_redis_cluster_name"
+#     replication: "sentinel"
+#     parameters:
+#       password: "some_secret_password"
+#       database: 12
 
 # default:
 #    expiry_time: 604800 # Default expiry time of Redis keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  app_5_3:
+    build:
+      context: .
+      dockerfile: 'docker/app_5_3/Dockerfile'
+    volumes:
+      - ".:/php-resque"
+    working_dir: '/php-resque'
+

--- a/docker/app_5_3/Dockerfile
+++ b/docker/app_5_3/Dockerfile
@@ -1,0 +1,16 @@
+FROM tomsowerby/php-5.3
+
+RUn apt-get update -yqq && apt-get upgrade -yqq
+
+RUN apt-get install -yqq git-core
+
+RUN pecl install -o -f redis &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis
+
+# composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN docker-php-ext-install pcntl
+
+
+CMD composer install -v && tail -f /dev/null
+

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -92,7 +92,8 @@ class Resque
             'namespace'  => static::getConfig('redis.namespace', Redis::DEFAULT_NS),
             'password'   => static::getConfig('redis.password', Redis::DEFAULT_PASSWORD),
             'rw_timeout' => static::getConfig('redis.rw_timeout', Redis::DEFAULT_RW_TIMEOUT),
-            'phpiredis'  => static::getConfig('redis.phpiredis', Redis::DEFAULT_PHPIREDIS)
+            'phpiredis'  => static::getConfig('redis.phpiredis', Redis::DEFAULT_PHPIREDIS),
+            'predis'     => static::getConfig('predis'),
         ));
 
         return true;

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -223,7 +223,7 @@ class Redis
         }
 
         // create Predis client
-        $this->redis = new Predis\Client($params, $options);
+        $this->initializePredisClient($params, $options);
 
         // setup namespace
         if (!empty($config['namespace'])) {
@@ -234,6 +234,17 @@ class Redis
 
         // Do this to test connection is working now rather than later
         $this->redis->connect();
+    }
+
+    /**
+     * initialize the redis member with a predis client.
+     * isolated call for testability
+     * @param array $config predis config parameters
+     * @param array $options predis optional parameters
+     * @return null
+     */
+    private function initializePredisClient($config, $options) {
+      $this->redis = new Predis\Client($config, $options);
     }
 
     /**

--- a/src/Resque/Redis.php
+++ b/src/Resque/Redis.php
@@ -12,7 +12,6 @@
 namespace Resque;
 
 use Predis;
-use Resque\Helpers\Stats;
 
 /**
  * Resque redis class
@@ -43,8 +42,8 @@ class Redis
     const DEFAULT_NS = 'resque';
 
     /**
-    * Default Redis AUTH password
-    */
+     * Default Redis AUTH password
+     */
     const DEFAULT_PASSWORD = null;
 
     /**
@@ -53,8 +52,8 @@ class Redis
     const DEFAULT_RW_TIMEOUT = 60;
 
     /**
-    * Default Redis option for using phpiredis or not
-    */
+     * Default Redis option for using phpiredis or not
+     */
     const DEFAULT_PHPIREDIS = false;
 
     /**
@@ -67,7 +66,7 @@ class Redis
         'namespace'  => self::DEFAULT_NS,
         'password'   => self::DEFAULT_PASSWORD,
         'rw_timeout' => self::DEFAULT_RW_TIMEOUT,
-        'phpiredis'  => self::DEFAULT_PHPIREDIS
+        'phpiredis'  => self::DEFAULT_PHPIREDIS,
     );
 
     /**
@@ -194,36 +193,48 @@ class Redis
      */
     public function __construct(array $config = array())
     {
-        // configuration params array
-        $params = array(
-            'scheme' => $config['scheme'],
-            'host'   => $config['host'],
-            'port'   => $config['port']
-        );
+        $predisParams  = array();
+        $predisOptions = array();
+        if (!empty($config['predis'])) {
+            $predisParams  = $config['predis']['config'];
+            $predisOptions = $config['predis']['options'];
+        } else {
+            foreach (array('scheme', 'host', 'port') as $key) {
+                if (!isset($config[$key])) {
+                    throw new \InvalidArgumentException("key '{$key}' is missing in redis configuration");
+                }
+            }
 
-        // setup password
-        if (!empty($config['password'])) {
-            $params['password'] = $config['password'];
-        }
-
-        // setup read/write timeout
-        if (!empty($config['rw_timeout'])) {
-            $params['read_write_timeout'] = $config['rw_timeout'];
-        }
-
-        // setup predis client options
-        $options = array();
-        if (!empty($config['phpiredis'])) {
-            $options = array(
-                'connections' => array(
-                    'tcp'  => 'Predis\Connection\PhpiredisStreamConnection',
-                    'unix' => 'Predis\Connection\PhpiredisSocketConnection'
-                ),
+            // non-optional configuration parameters
+            $predisParams = array(
+                'scheme' => $config['scheme'],
+                'host'   => $config['host'],
+                'port'   => $config['port'],
             );
+
+            // setup password
+            if (!empty($config['password'])) {
+                $predisParams['password'] = $config['password'];
+            }
+
+            // setup read/write timeout
+            if (!empty($config['rw_timeout'])) {
+                $predisParams['read_write_timeout'] = $config['rw_timeout'];
+            }
+
+            // setup predis client options
+            if (!empty($config['phpiredis'])) {
+                $predisOptions = array(
+                    'connections' => array(
+                        'tcp'  => 'Predis\Connection\PhpiredisStreamConnection',
+                        'unix' => 'Predis\Connection\PhpiredisSocketConnection',
+                    ),
+                );
+            }
         }
 
         // create Predis client
-        $this->initializePredisClient($params, $options);
+        $this->redis = $this->initializePredisClient($predisParams, $predisOptions);
 
         // setup namespace
         if (!empty($config['namespace'])) {
@@ -243,8 +254,9 @@ class Redis
      * @param array $options predis optional parameters
      * @return null
      */
-    private function initializePredisClient($config, $options) {
-      $this->redis = new Predis\Client($config, $options);
+    public function initializePredisClient($config, $options)
+    {
+        return new Predis\Client($config, $options);
     }
 
     /**
@@ -288,7 +300,7 @@ class Redis
         }
 
         if (strpos($string, $this->namespace) !== 0) {
-            $string = $this->namespace.$string;
+            $string = $this->namespace . $string;
         }
 
         return $string;
@@ -328,7 +340,7 @@ class Redis
         return call_user_func_array(array($this->redis, $method), $parameters);
 
         // } catch (\Exception $e) {
-        // 	return false;
+        //     return false;
         // }
     }
 }

--- a/tests/Resque/Helpers/UtilTest.php
+++ b/tests/Resque/Helpers/UtilTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Resque\Tests\Helpers\Utils;
+namespace Resque\Tests\Helpers;
 
 use Resque\Helpers\Util;
 use PHPUnit\Framework\TestCase;

--- a/tests/Resque/Helpers/UtilTest.php
+++ b/tests/Resque/Helpers/UtilTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Resque\Tests\Heplers\Utils;
+namespace Resque\Tests\Helpers\Utils;
 
 use Resque\Helpers\Util;
 use PHPUnit\Framework\TestCase;

--- a/tests/Resque/RedisTest.php
+++ b/tests/Resque/RedisTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Resque\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class RedisTest extends TestCase
+{
+
+    private $legacyParameters = array(
+        'scheme'     => 'tcp',
+        'host'       => 'redis_instance_01',
+        'port'       => 6379,
+        'namespace'  => 'some_namespace',
+        'rw_timeout' => 123,
+        'phpiredis'  => true,
+    );
+
+    private $predisNativeParameters = array(
+        'config'  => array(
+            array(
+                'tcp://10.0.0.1',
+                'tcp://10.0.0.2',
+                'tcp://10.0.0.3',
+            ),
+        ),
+        'options' => array(
+            'replication' => 'sentinel',
+            'service'     => 'some_redis_cluster',
+            'parameters'  => array(
+                'password' => 'some_secure_password',
+                'database' => 10,
+            ),
+        ),
+    );
+
+    private $predisMock = null;
+
+    private $redisMock = null;
+
+    public function setUp()
+    {
+
+        $predisClassName = "\\Predis\\Client";
+
+        $this->predisMock = $this->getMockBuilder($predisClassName)
+            ->disableOriginalConstructor()
+            ->setMethods(array('connect'))
+            ->getMock()
+        ;
+
+        $className = "\\Resque\\Redis";
+
+        $this->redisMock = $this->getMockBuilder($className)
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializePredisClient'))
+            ->getMock()
+        ;
+
+    }
+
+    public function tearDown()
+    {
+        $this->predisMock = null;
+    }
+
+    public function testConstructorShouldDoTheLegacyStuff()
+    {
+
+        $this->redisMock->expects($this->once())
+            ->method('initializePredisClient')
+            ->with(
+                array(
+                    'scheme'             => $this->legacyParameters['scheme'],
+                    'host'               => $this->legacyParameters['host'],
+                    'port'               => $this->legacyParameters['port'],
+                    'read_write_timeout' => $this->legacyParameters['rw_timeout'],
+                ),
+                array(
+                    'connections' => array(
+                        'tcp'  => 'Predis\Connection\PhpiredisStreamConnection',
+                        'unix' => 'Predis\Connection\PhpiredisSocketConnection',
+                    ),
+                )
+            )
+            ->willReturn($this->predisMock)
+        ;
+
+        $this->predisMock->expects($this->any())->method('connect');
+
+        $this->redisMock->__construct($this->legacyParameters);
+    }
+
+    public function testConstructorShouldAcceptPredisOverride()
+    {
+        $className = "\\Resque\\Redis";
+
+        $this->redisMock = $this->getMockBuilder($className)
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializePredisClient'))
+            ->getMock()
+        ;
+
+        $this->redisMock->expects($this->once())
+            ->method('initializePredisClient')
+            ->with(
+                $this->predisNativeParameters['config'],
+                $this->predisNativeParameters['options']
+            )
+            ->willReturn($this->predisMock)
+        ;
+
+        $this->predisMock->expects($this->any())->method('connect');
+
+        $this->redisMock->__construct(array_merge($this->legacyParameters, array('predis' => $this->predisNativeParameters)));
+    }
+
+}


### PR DESCRIPTION
the current wrapper class does not allow for a deviation from "one redis server" configuration variant of predis.

As Resque in itself is a technology one usually uses in more complex setups, the need for a more complex redis-setup arises.
The provided predis version does have all these options, but the wrapper is too limited.

This patch allows for direct configuration of predis via the predis section in the `config.yml`
it effectively overrides anything configured in the redis section, so one has to chose.

I provided a sentinel example for that.

In addition i added the following things for a brighter future:
- `Dockerfile` file for testing 
- `docker-compose.yml` file for testing
- a basic editorconfig
- 2 tests (Redis with legacy initialization, Redis with override initialization)
- a `.gitattributes` file

if this gets merged i also have the tools to work on the handler thing again (#85 )


best regards,
scones
