### PR TITLE
Fix issue when calling cli_set_process_title on osx

### DIFF
--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -1257,7 +1257,7 @@ class Worker
     protected function updateProcLine($status)
     {
         $status = $this->getProcessTitle($status);
-        if (function_exists('cli_set_process_title')) {
+        if (function_exists('cli_set_process_title') && PHP_OS !== 'Darwin') {
             cli_set_process_title($status);
             return;
         }


### PR DESCRIPTION
Unless the worker is running under root, cli_set_process_title() will return "cli_set_process_title had an error: Not initialized correctly" when run on osx.