### PR TITLE
workaround: child send "suicide" signal for "correct" handling in parent process

### DIFF
--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -347,6 +347,12 @@ class Worker
 
                 Event::fire(Event::WORKER_FORK_CHILD, array($this, $job, getmypid()));
 
+                register_shutdown_function(
+                    function() {
+                        posix_kill(getmypid(), SIGKILL);
+                    }
+                );
+
                 $this->log('Running job <pop>'.$job.'</pop>', Logger::INFO);
                 $this->updateProcLine('Job: processing '.$job->getQueue().'#'.$job->getId().' since '.strftime('%F %T'));
 


### PR DESCRIPTION
In some situations child process hangs on shutdown phase (probably in buggy extensions)  and parent process hangs in unanswered "pcntl_wait"

see https://www.php.net/manual/en/function.pcntl-fork.php#106860