### PR TITLE
Bump PHP version requirement to 7.1+, support Symfony v4 and v5 components

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _A web interface for this version is currently in development, if you want to kn
 You must have the following installed in order to run php-resque:
 
 * [Redis](http://redis.io/)
-* [PHP 5.3+](http://php.net/)
+* [PHP 7.1+](http://php.net/)
 * [PCNTL PHP extension](http://php.net/manual/en/book.pcntl.php)
 * [Composer](http://getcomposer.org/)
 
@@ -81,7 +81,7 @@ Add php-resque to your application's `composer.json` file:
 ```json
 {
     "require": {
-        "mjphaynes/php-resque": "2.1.*"
+        "mjphaynes/php-resque": "3.0.*"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "ext-pcntl": "*",
         "predis/predis": "1.1.*",
         "monolog/monolog": "~1.7",
-        "symfony/console": "~2.7|~3.0|~4.0|~5.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0|5.0"
+        "symfony/console": "~3.0|~4.0|~5.0",
+        "symfony/yaml": "~3.0|~4.0|~5.0"
     },
     "suggest": {
         "ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker in PHP versions < 5.5.0.",
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
-        "symfony/process": "~2.7|~3.0|~4.0|5.0"
+        "symfony/process": "~3.0|~4.0|~5.0"
     },
     "bin": [
         "bin/resque"

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1.0",
         "ext-pcntl": "*",
         "predis/predis": "1.1.*",
         "monolog/monolog": "~1.7",
-        "symfony/console": "~2.7|~3.0",
-        "symfony/yaml": "~2.7|~3.0"
+        "symfony/console": "~2.7|~3.0|~4.0|~5.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0|5.0"
     },
     "suggest": {
         "ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker in PHP versions < 5.5.0.",
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
-        "symfony/process": "~2.7|~3.0"
+        "symfony/process": "~2.7|~3.0|~4.0|5.0"
     },
     "bin": [
         "bin/resque"

--- a/src/Resque/Commands/Cleanup.php
+++ b/src/Resque/Commands/Cleanup.php
@@ -13,10 +13,8 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Cleanup.php
+++ b/src/Resque/Commands/Cleanup.php
@@ -51,5 +51,7 @@ class Cleanup extends Command
         $this->log('Cleaned workers: <pop>'.json_encode(array_merge($cleaned_hosts['workers'], $cleaned_workers)).'</pop>');
         $this->log('Cleaned <pop>'.$cleaned_jobs['zombie'].'</pop> zombie job'.($cleaned_jobs['zombie'] == 1 ? '' : 's'));
         $this->log('Cleared <pop>'.$cleaned_jobs['processed'].'</pop> processed job'.($cleaned_jobs['processed'] == 1 ? '' : 's'));
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Clear.php
+++ b/src/Resque/Commands/Clear.php
@@ -13,10 +13,8 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 

--- a/src/Resque/Commands/Clear.php
+++ b/src/Resque/Commands/Clear.php
@@ -55,6 +55,8 @@ class Clear extends Command
             }
 
             $output->writeln('<pop>Done.</pop>');
+
+            return self::SUCCESS;
         }
     }
 }

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -26,6 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Command extends \Symfony\Component\Console\Command\Command
 {
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+    public const INVALID = 2;
 
     /**
      * @var Logger The logger instance

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -13,10 +13,8 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Helpers\Util;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Hosts.php
+++ b/src/Resque/Commands/Hosts.php
@@ -13,9 +13,7 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Resque/Commands/Hosts.php
+++ b/src/Resque/Commands/Hosts.php
@@ -56,5 +56,7 @@ class Hosts extends Command
         }
 
         $this->log((string)$table);
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Job/Queue.php
+++ b/src/Resque/Commands/Job/Queue.php
@@ -16,7 +16,6 @@ use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Job/Queue.php
+++ b/src/Resque/Commands/Job/Queue.php
@@ -70,21 +70,23 @@ class Queue extends Command
             $delay = (int)$delay;
         } else {
             $this->log('Delay option "'.$delay.'" is invalid type "'.gettype($delay).'", value must be an integer.', Logger::ERROR);
-            return;
+            return self::INVALID;
         }
 
         if ($delay) {
             if ($job = Resque::later($delay, $job, $args, $queue)) {
                 $this->log('Job <pop>'.$job.'</pop> will be queued at <pop>'.date('r', $job->getDelayedTime()).'</pop> on <pop>'.$job->getQueue().'</pop> queue.');
-                return;
+                return self::SUCCESS;
             }
         } else {
             if ($job = Resque::push($job, $args, $queue)) {
                 $this->log('Job <pop>'.$job.'</pop> added to <pop>'.$job->getQueue().'</pop> queue.');
-                return;
+                return self::SUCCESS;
             }
         }
 
         $this->log('Error, job was not queued. Please try again.', Logger::ERROR);
+
+        return self::FAILURE;
     }
 }

--- a/src/Resque/Commands/Queues.php
+++ b/src/Resque/Commands/Queues.php
@@ -13,10 +13,8 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Queues.php
+++ b/src/Resque/Commands/Queues.php
@@ -63,5 +63,7 @@ class Queues extends Command
         }
 
         $this->log((string)$table);
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Socket/Connect.php
+++ b/src/Resque/Commands/Socket/Connect.php
@@ -13,10 +13,8 @@ namespace Resque\Commands\Socket;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Socket/Connect.php
+++ b/src/Resque/Commands/Socket/Connect.php
@@ -112,5 +112,7 @@ class Connect extends Command
         }
 
         fclose($fh);
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Socket/Receive.php
+++ b/src/Resque/Commands/Socket/Receive.php
@@ -14,7 +14,6 @@ namespace Resque\Commands\Socket;
 use Resque;
 use Resque\Job;
 use Resque\Host;
-use Resque\Redis;
 use Resque\Worker;
 use Resque\Socket;
 use Resque\Helpers\Util;
@@ -23,7 +22,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Resque/Commands/Socket/Receive.php
+++ b/src/Resque/Commands/Socket/Receive.php
@@ -285,6 +285,8 @@ class Receive extends Command
         });
 
         $server->run();
+
+        return self::SUCCESS;
     }
 
     public function pollingConsoleOutput()

--- a/src/Resque/Commands/Socket/Send.php
+++ b/src/Resque/Commands/Socket/Send.php
@@ -74,5 +74,7 @@ class Send extends Command
         $this->log('<pop>'.trim($response).'</pop>');
 
         fclose($fh);
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Socket/Send.php
+++ b/src/Resque/Commands/Socket/Send.php
@@ -16,7 +16,6 @@ use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/SpeedTest.php
+++ b/src/Resque/Commands/SpeedTest.php
@@ -76,6 +76,8 @@ class SpeedTest extends Command
         foreach ($keys as $key) {
             $redis->del($key);
         }
+
+        return self::SUCCESS;
     }
 
     // http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x361.html

--- a/src/Resque/Commands/SpeedTest.php
+++ b/src/Resque/Commands/SpeedTest.php
@@ -13,13 +13,10 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Console\Helper\ProgressBar;
 
 use Exception;
 

--- a/src/Resque/Commands/Worker/Cancel.php
+++ b/src/Resque/Commands/Worker/Cancel.php
@@ -16,7 +16,6 @@ use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Cancel.php
+++ b/src/Resque/Commands/Worker/Cancel.php
@@ -48,7 +48,7 @@ class Cancel extends Command
         if ($id) {
             if (false === ($worker = Resque\Worker::hostWorker($id))) {
                 $this->log('There is no worker with id "'.$id.'".', Resque\Logger::ERROR);
-                return;
+                return self::FAILURE;
             }
 
             $workers = array($worker);
@@ -74,5 +74,7 @@ class Cancel extends Command
                 $this->log('Worker <pop>'.$worker.'</pop> has no running job.');
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Worker/Pause.php
+++ b/src/Resque/Commands/Worker/Pause.php
@@ -48,7 +48,7 @@ class Pause extends Command
         if ($id) {
             if (false === ($worker = Resque\Worker::hostWorker($id))) {
                 $this->log('There is no worker with id "'.$id.'".', Resque\Logger::ERROR);
-                return;
+                return self::FAILURE;
             }
 
             $workers = array($worker);
@@ -67,5 +67,7 @@ class Pause extends Command
                 $this->log('Worker <pop>'.$worker.'</pop> <error>could not send USR2 signal.</error>');
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Worker/Pause.php
+++ b/src/Resque/Commands/Worker/Pause.php
@@ -15,8 +15,6 @@ use Resque;
 use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Restart.php
+++ b/src/Resque/Commands/Worker/Restart.php
@@ -48,7 +48,7 @@ class Restart extends Command
         if ($id) {
             if (false === ($worker = Resque\Worker::hostWorker($id))) {
                 $this->log('There is no worker with id "'.$id.'".', Resque\Logger::ERROR);
-                return;
+                return self::FAILURE;
             }
 
             $workers = array($worker);
@@ -89,6 +89,6 @@ class Restart extends Command
             }
         }
 
-        exit(0);
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Worker/Restart.php
+++ b/src/Resque/Commands/Worker/Restart.php
@@ -15,8 +15,6 @@ use Resque;
 use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Resume.php
+++ b/src/Resque/Commands/Worker/Resume.php
@@ -67,5 +67,7 @@ class Resume extends Command
                 $this->log('Worker <pop>'.$worker.'</pop> <error>could not send CONT signal.</error>');
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Worker/Resume.php
+++ b/src/Resque/Commands/Worker/Resume.php
@@ -15,8 +15,6 @@ use Resque;
 use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Start.php
+++ b/src/Resque/Commands/Worker/Start.php
@@ -13,10 +13,8 @@ namespace Resque\Commands\Worker;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Start.php
+++ b/src/Resque/Commands/Worker/Start.php
@@ -71,6 +71,8 @@ class Start extends Command
         }
 
         $worker->work();
+
+        return self::SUCCESS;
     }
 
     public function pollingConsoleOutput()

--- a/src/Resque/Commands/Worker/Stop.php
+++ b/src/Resque/Commands/Worker/Stop.php
@@ -16,7 +16,6 @@ use Resque\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Worker/Stop.php
+++ b/src/Resque/Commands/Worker/Stop.php
@@ -49,7 +49,7 @@ class Stop extends Command
         if ($id) {
             if (false === ($worker = Resque\Worker::hostWorker($id))) {
                 $this->log('There is no worker with id "'.$id.'".', Resque\Logger::ERROR);
-                return;
+                return self::FAILURE;
             }
 
             $workers = array($worker);
@@ -70,5 +70,7 @@ class Stop extends Command
                 $this->log('Worker <pop>'.$worker.'</pop> <error>could not send '.$sig.' signal.</error>');
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Resque/Commands/Workers.php
+++ b/src/Resque/Commands/Workers.php
@@ -13,10 +13,8 @@ namespace Resque\Commands;
 
 use Resque;
 use Resque\Commands\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Resque/Commands/Workers.php
+++ b/src/Resque/Commands/Workers.php
@@ -68,5 +68,7 @@ class Workers extends Command
         }
 
         $this->log((string)$table);
+
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master / 3.0
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes (requires Symfony components 3.x, 4.x or 5.x, PHP 7.1+)
| Deprecations? | no
| Fixed tickets | #71 #78 (for what can be done without creating a second repo)
| Credits | @xelan