### PR TITLE
Fix deprecation warnings on PHP 8.1

### DIFF
--- a/src/Resque.php
+++ b/src/Resque.php
@@ -24,7 +24,7 @@ class Resque
     /**
      * php-resque version
      */
-    const VERSION = '2.2.0';
+    const VERSION = '3.1.1';
 
     /**
      * How long the job and worker data will remain in Redis for

--- a/src/Resque/Commands/Command.php
+++ b/src/Resque/Commands/Command.php
@@ -141,7 +141,7 @@ class Command extends \Symfony\Component\Console\Command\Command
         unset($logs, $handlerConnector, $handlers);
 
         // Include file?
-        if (array_key_exists('include', $config) and strlen($include = $config['include'])) {
+        if (array_key_exists('include', $config) and !empty($include = $config['include'])) {
             if (
                 !($includeFile = realpath(dirname($include).'/'.basename($include))) or
                 !is_readable($includeFile) or !is_file($includeFile) or

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -144,7 +144,7 @@ class Job
     {
         $id = dechex(crc32($queue)).
             dechex((int)(microtime(true) * 1000)).
-            md5(json_encode($class).json_encode($data).$run_at);
+            md5(json_encode($class).json_encode($data).$run_at.uniqid('', true));
 
         return substr($id, 0, self::ID_LENGTH);
     }

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -143,8 +143,8 @@ class Job
     public static function createId($queue, $class, $data = null, $run_at = 0)
     {
         $id = dechex(crc32($queue)).
-            dechex(microtime(true) * 1000).
-            md5(json_encode($class).json_encode($data).$run_at.uniqid('', true));
+            dechex((int)(microtime(true) * 1000)).
+            md5(json_encode($class).json_encode($data).$run_at);
 
         return substr($id, 0, self::ID_LENGTH);
     }

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -367,8 +367,7 @@ class Job
         if (!class_exists($this->class)) {
             throw new \RuntimeException('Could not find job class "'.$this->class.'"');
         }
-
-        if (!method_exists($this->class, $this->method) or !is_callable(array($this->class, $this->method))) {
+        if (!method_exists($this->class, $this->method)) {
             throw new \RuntimeException('Job class "'.$this->class.'" does not contain a public "'.$this->method.'" method');
         }
 

--- a/src/Resque/Logger/Processor/ConsoleProcessor.php
+++ b/src/Resque/Logger/Processor/ConsoleProcessor.php
@@ -57,7 +57,7 @@ class ConsoleProcessor
     {
         if ($this->command->pollingConsoleOutput()) {
             if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                $record['message'] = sprintf('** [%s] %s', strftime('%T %Y-%m-%d'), $record['message']);
+                $record['message'] = sprintf('** [%s] %s', date('H:i:s Y-m-d'), $record['message']);
             } else {
                 $record['message'] = sprintf('** %s', $record['message']);
             }

--- a/src/Resque/Queue.php
+++ b/src/Resque/Queue.php
@@ -136,7 +136,9 @@ class Queue
 
         if ($blocking) {
             list($queue, $payload) = $this->redis->blpop($queues, $timeout);
-            $queue = $this->redis->removeNamespace($queue);
+            if ($queue) {
+                $queue = $this->redis->removeNamespace($queue);
+            }
         } else {
             foreach ($queues as $queue) {
                 if ($payload = $this->redis->lpop($queue)) {

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -121,26 +121,26 @@ class Worker
      * @var array Signal handler method name mapping
      */
     protected $signalHandlerMapping = array(
-        SIGTERM => 'sigForceShutdown',
-        SIGINT  => 'sigForceShutdown',
-        SIGQUIT => 'sigShutdown',
-        SIGUSR1 => 'sigCancelJob',
-        SIGUSR2 => 'sigPause',
-        SIGCONT => 'sigResume',
-        SIGPIPE => 'sigWakeUp',
+        \SIGTERM => 'sigForceShutdown',
+        \SIGINT  => 'sigForceShutdown',
+        \SIGQUIT => 'sigShutdown',
+        \SIGUSR1 => 'sigCancelJob',
+        \SIGUSR2 => 'sigPause',
+        \SIGCONT => 'sigResume',
+        \SIGPIPE => 'sigWakeUp',
     );
 
     /**
      * @var array List of shutdown errors to catch
      */
     protected $shutdownErrors = array(
-        E_PARSE,
-        E_ERROR,
-        E_USER_ERROR,
-        E_CORE_ERROR,
-        E_CORE_WARNING,
-        E_COMPILE_ERROR,
-        E_COMPILE_WARNING
+        \E_PARSE,
+        \E_ERROR,
+        \E_USER_ERROR,
+        \E_CORE_ERROR,
+        \E_CORE_WARNING,
+        \E_COMPILE_ERROR,
+        \E_COMPILE_WARNING
     );
 
     /**

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -324,7 +324,7 @@ class Worker
                 Event::fire(Event::WORKER_FORK_PARENT, array($this, $job, $this->child));
 
                 $this->log('Forked process to run job on pid:'.$this->child, Logger::DEBUG);
-                $this->updateProcLine('Worker: forked '.$this->child.' at '.strftime('%F %T'));
+                $this->updateProcLine('Worker: forked '.$this->child.' at '.date('Y-m-d H:i:s'));
 
                 // Set the PID in redis
                 $this->redis->hset(self::redisKey($this), 'job_pid', $this->child);
@@ -348,7 +348,7 @@ class Worker
                 Event::fire(Event::WORKER_FORK_CHILD, array($this, $job, getmypid()));
 
                 $this->log('Running job <pop>'.$job.'</pop>', Logger::INFO);
-                $this->updateProcLine('Job: processing '.$job->getQueue().'#'.$job->getId().' since '.strftime('%F %T'));
+                $this->updateProcLine('Job: processing '.$job->getQueue().'#'.$job->getId().' since '.date('Y-m-d H:i:s'));
 
                 $this->perform($job);
                 exit(0);


### PR DESCRIPTION
`strftime` -> `date`
`strlen($null)` -> `!empty($null)`
`dechex($float)` -> `dechex((int)$float)`
remove `is_callable(['classname', 'method'])`

Also some minor fixes and bump staled `Resque::VERSION`