### PR TITLE
setConfig method, refactor, adopt changes by @AvinashRavula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Support for PHP and JSON configuration files
 
+-   `setConfig` method to set the configuration array directly (as an alternative to `loadConfig`)
+
 -   Extendable console application class
 
 -   Job blueprint class as a base for all jobs
 
 -   Jobs' `setUp` and `tearDown` methods now receive the `Resque\Job` instance as an argument
+
+-   `setQueue` method to make it possible to override the queue behavior
 
 -   Docker environment for development
 

--- a/autoload.php
+++ b/autoload.php
@@ -13,6 +13,7 @@
  * Autoload file for php-resque speedtest feature.
  */
 
+use Monolog\Handler\StreamHandler;
 use Resque\Event;
 use Resque\Logger;
 use Resque\Resque;
@@ -25,6 +26,8 @@ class TestJob
         // Don't do anything
     }
 }
+
+$logger = new Logger([new StreamHandler('php://stdout')]);
 
 // Lets record the forking time
 Event::listen([Event::WORKER_FORK, Event::WORKER_FORK_CHILD], function ($event, $job) use ($logger): void {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,9 +27,9 @@ You can set the configuration file path when running any command:
 When adding jobs to the queue, you just can add the config file location as a parameter:
 
 ```php
-use Resque\Config;
+use Resque\Resque;
 
-Config::loadConfig('my-custom-config.yml');
+Resque::loadConfig('/path/to/my-custom-config.yml');
 
 $payload = [
     'some' => 'data',
@@ -40,6 +40,14 @@ $job = Resque::push(
     $payload,
     'default'
 );
+```
+
+Or, if you prefer, you can set the configuration array directly:
+
+```php
+use Resque\Resque;
+
+Resque::setConfig([ ... ]);
 ```
 
 ---

--- a/src/Config.php
+++ b/src/Config.php
@@ -155,8 +155,6 @@ final class Config
      *
      * @param string $key     The key to search for (optional)
      * @param mixed  $default If key not found returns this (optional)
-     *
-     * @return mixed
      */
     public static function read(?string $key = null, $default = null)
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -53,8 +53,10 @@ final class Config
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
+     *
+     * @return array<string, mixed> The configuration array
      */
-    public static function loadConfig(string $file = self::DEFAULT_CONFIG_FILE): void
+    public static function loadConfig(string $file = self::DEFAULT_CONFIG_FILE): array
     {
         [$path, $ext] = static::getConfigDetails($file);
 
@@ -76,6 +78,8 @@ final class Config
         }
 
         static::setConfig($config);
+
+        return $config;
     }
 
     /**

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -209,7 +209,7 @@ class Command extends \Symfony\Component\Console\Command\Command
     protected function parseConfig(array $config, array $defaults): bool
     {
         if (array_key_exists('config', $config)) {
-            $configFileData = Config::parseConfig($config['config']);
+            $configFileData = Config::loadConfig($config['config']);
 
             foreach ($config as $key => &$value) {
                 // If the config value is equal to the default value set in the command then

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -191,8 +191,7 @@ class Command extends \Symfony\Component\Console\Command\Command
     /**
      * Helper function that passes through to logger instance
      *
-     * @see Logger::log
-     * @return mixed
+     * @see Logger::log for more information
      */
     public function log()
     {

--- a/src/Helpers/SerializableClosure.php
+++ b/src/Helpers/SerializableClosure.php
@@ -224,8 +224,6 @@ final class SerializableClosure implements \Serializable
 
     /**
      * Invoke the contained Closure.
-     *
-     * @return mixed
      */
     public function __invoke()
     {

--- a/src/Helpers/Table.php
+++ b/src/Helpers/Table.php
@@ -70,8 +70,6 @@ final class Table
      *
      * @param string $method
      * @param array  $parameters
-     *
-     * @return mixed
      */
     public function __call(string $method, array $parameters)
     {

--- a/src/Job.php
+++ b/src/Job.php
@@ -108,10 +108,10 @@ final class Job
      *
      * @param string          $queue  The name of the queue to place the job in
      * @param string|callable $class  The name of the class that contains the code to execute the job
-     * @param array           $data   Any optional arguments that should be passed when the job is executed
+     * @param array|null      $data   Any optional arguments that should be passed when the job is executed
      * @param int             $run_at Unix timestamp of when to run the job to delay execution
      *
-     * @return Job
+     * @return Job|null
      */
     public static function create(string $queue, $class, ?array $data = null, int $run_at = 0): ?self
     {
@@ -157,7 +157,7 @@ final class Job
      *
      * @param string $id The job id
      *
-     * @return static
+     * @return static|null
      */
     public static function load(string $id): ?self
     {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -76,9 +76,9 @@ final class Logger
     ];
 
     /**
-     * @var Monolog|null The monolog instance
+     * @var Monolog The monolog instance
      */
-    protected $instance = null;
+    protected $instance;
 
     /**
      * Create a Monolog instance and attach a handler
@@ -108,13 +108,11 @@ final class Logger
     /**
      * Send log message to output interface
      *
-     * @param string $message Message to output
-     * @param mixed  $context Some context around the log
-     * @param int    $logType The log type
-     *
-     * @return mixed
+     * @param string   $message Message to output
+     * @param mixed    $context Some context around the log
+     * @param int|null $logType The log type
      */
-    public function log(string $message, $context = null, int $logType = Monolog::INFO)
+    public function log(string $message, $context = null, ?int $logType = null)
     {
         if (is_int($context) and is_null($logType)) {
             $logType = $context;
@@ -123,6 +121,10 @@ final class Logger
 
         if (!is_array($context)) {
             $context = is_null($context) ? [] : [$context];
+        }
+
+        if (!in_array($logType, $this->instance->getLevels())) {
+            $logType = Monolog::INFO;
         }
 
         return call_user_func([$this->instance, $this->logTypes[$logType]], $message, $context);

--- a/src/Logger/Handler/Connector/AbstractConnector.php
+++ b/src/Logger/Handler/Connector/AbstractConnector.php
@@ -33,7 +33,7 @@ abstract class AbstractConnector implements ConnectorInterface
      * @param OutputInterface $output
      * @param array           $args
      *
-     * @return StripProcessor
+     * @return StripFormatProcessor
      */
     public function processor(Command $command, InputInterface $input, OutputInterface $output, array $args)
     {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -79,7 +79,7 @@ class Queue
      *
      * @return Job job instance
      */
-    public function push($job, ?array $data = null, ?string $queue = null): Job
+    public function push($job, ?array $data = [], ?string $queue = null): Job
     {
         if (false !== ($delay = Config::read('default.jobs.delay', false))) {
             return $this->later($delay, $job, $data, $queue);

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -17,7 +17,7 @@ namespace Resque;
  * @package Resque
  * @author Michael Haynes <mike@mjphaynes.com>
  */
-final class Queue
+class Queue
 {
     /**
      * @var Redis The Redis instance

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -16,6 +16,8 @@ use Predis\Client;
 /**
  * Resque redis class
  *
+ * @see https://redis.io/commands
+ *
  * @package Resque
  * @author Michael Haynes <mike@mjphaynes.com>
  */
@@ -327,9 +329,8 @@ class Redis
     /**
      * Dynamically pass calls to the Predis.
      *
-     * @param  string $method     Method to call
-     * @param  array  $parameters Arguments to send to method
-     * @return mixed
+     * @param string $method     Method to call
+     * @param array  $parameters Arguments to send to method
      */
     public function __call(string $method, array $parameters)
     {

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -167,7 +167,7 @@ class Redis
      *
      * @param array $config Array of configuration settings
      */
-    final public function __construct(array $config = [])
+    public function __construct(array $config = [])
     {
         $predisParams  = [];
         $predisOptions = [];

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -25,6 +25,8 @@ namespace Resque;
  * @method static int               size(string $queue) Get the size (number of pending jobs)        of the specified queue.
  * @method static int               sizeDelayed(string $queue) Get the size (number of delayed jobs) of the specified queue.
  * @method static string            getQueue(?string $queue)                                         Get the queue or return the default.
+ * @method static void              loadConfig(string $file = self::DEFAULT_CONFIG_FILE)             Read and load data from a config file
+ * @method static void              setConfig(array $config)                                         Set the configuration array
  */
 class Resque
 {
@@ -62,9 +64,12 @@ class Resque
      */
     public static function __callStatic(string $method, array $parameters)
     {
-        $callable = [static::queue(), $method];
+        // Simplify the call to setConfig and loadConfig
+        if (in_array($method, ['setConfig', 'loadConfig'])) {
+            return call_user_func_array([Config::class, $method], $parameters);
+        }
 
-        return call_user_func_array($callable, $parameters);
+        return call_user_func_array([static::queue(), $method], $parameters);
     }
 
     /**

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -20,7 +20,7 @@ namespace Resque;
  * @method static string            redisKey(?string $queue = null, ?string $suffix = null)          Get the Queue key.
  * @method static \Resque\Job       job(string $id)                                                  Get a job by id.
  * @method static \Resque\Job       push($job, ?array $data = null, ?string $queue = null)           Push a new job onto the queue.
- * @method static \Resque\Job       later($job, ?array $data = null, ?string $queue = null)          Queue a job for later retrieval.
+ * @method static \Resque\Job       later($delay, $job, array $data = [], ?string $queue = null)     Queue a job for later retrieval.
  * @method static \Resque\Job|false pop(array $queues, int $timeout = 10, bool $blocking = true)     Pop the next job off of the queue.
  * @method static int               size(string $queue) Get the size (number of pending jobs)        of the specified queue.
  * @method static int               sizeDelayed(string $queue) Get the size (number of delayed jobs) of the specified queue.

--- a/src/Resque.php
+++ b/src/Resque.php
@@ -55,12 +55,22 @@ class Resque
     }
 
     /**
+     * Set the queue instance.
+     *
+     * @param Queue $queue The queue instance
+     *
+     * @return void
+     */
+    public static function setQueue(Queue $queue): void
+    {
+        static::$queue = $queue;
+    }
+
+    /**
      * Dynamically pass calls to the default connection.
      *
      * @param string $method     The method to call
      * @param array  $parameters The parameters to pass
-     *
-     * @return mixed
      */
     public static function __callStatic(string $method, array $parameters)
     {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -173,9 +173,9 @@ final class Worker
      * @param string $id     Worker id
      * @param Logger $logger Logger for the worker to use
      *
-     * @return Worker
+     * @return Worker|bool
      */
-    public static function fromId(string $id, ?Logger $logger = null): Worker
+    public static function fromId(string $id, ?Logger $logger = null)
     {
         if (!$id or !count($packet = Redis::instance()->hgetall(self::redisKey($id)))) {
             return false;
@@ -973,9 +973,9 @@ final class Worker
     /**
      * Set the worker queues
      *
-     * @param string $queues Queues for worker to watch
+     * @param array $queues Queues for worker to watch
      */
-    public function setQueues(string $queues): void
+    public function setQueues(array $queues): void
     {
         if ($this->status != self::STATUS_NEW) {
             throw new \RuntimeException('Cannot set worker queues after worker has started working');
@@ -1100,9 +1100,7 @@ final class Worker
     /**
      * Helper function that passes through to logger instance
      *
-     * @see    Logger::log For more documentation
-     *
-     * @return mixed
+     * @see    Logger::log For more information
      */
     public function log()
     {


### PR DESCRIPTION
Hello! I saw you merged my PR recently, thanks! I kind of battle-tested it in a private project and made some hotfixes/improvements:

- **Added public `setConfig` method to `Config.php` to pass parsed configuration array.** 
People might have their own file extensions and parsers for them, use something Resque doesn't support, or have some complicated bootstrap logic (my case), `setConfig` allows to set ready-to-go PHP config array.
- Removed the `parseConfig` method, its logic is now stored in the `loadConfig` method
- Refactored the `getConfigDetails` method to check if the user passed a valid path to the file; using `getcwd` instead of `realpath(dirname())`
- Added static call bridge to the `Resque` class to make accessing two main methods of the `Config` class easier
- Un`final`ed `Queue` class since people might want to extend it

I also adopted changes by @AvinashRavula in #116. His branch was based on the old v4 branch (version from March) and probably has a lot of merge conflicts by now, I decided to adopt the changes in my PR (based on the new version) and IMHO they look just great! Quote:

> 1. Addresses #114 
> 2. Fixes setQueues argument type
> 3. Fixes return type declarations
> 4. Adds missing $logger instance
> 5. Fixes the Logger class log method to correctly set the log type

For the future: we'd need to somehow maintain the array in Resque\Redis::$keyCommands. I guess it's for prefixing Redis keys for specific commands, gotta find a way to understand these commands, or hardcode all of those commands (way too many)

_Also, can I please ask for this PR to be merged sooner? 🙏🏻 I knew that basing a project on the "v4.x-dev" version was not a good idea, but now I got myself into trouble... had to manually change the source code in 'vendor'_ 